### PR TITLE
Fixes an issue with CI/CD on PR merges

### DIFF
--- a/admin/update.bash
+++ b/admin/update.bash
@@ -12,10 +12,13 @@ TOKEN_TIMER_FILE="${SCRIPT_DIR}/thumbsuptoken.timer"
 DBWRITE_SERVICE_FILE="${SCRIPT_DIR}/thumbsupdbwrite.service"
 DBWRITE_TIMER_FILE="${SCRIPT_DIR}/thumbsupdbwrite.timer"
 
+GITHUB_SHA=${GITHUB_SHA:-master}
+
 echo
 echo
 echo "Updating Thumbsup codebase at: ${THUMBSUP_DIR}"
-git -C "${THUMBSUP_DIR}" checkout master
+git -C "${THUMBSUP_DIR}" fetch origin
+git -C "${THUMBSUP_DIR}" checkout "$GITHUB_SHA"
 git -C "${THUMBSUP_DIR}" pull
 
 echo

--- a/admin/update.bash
+++ b/admin/update.bash
@@ -19,7 +19,6 @@ echo
 echo "Updating Thumbsup codebase at: ${THUMBSUP_DIR}"
 git -C "${THUMBSUP_DIR}" fetch origin
 git -C "${THUMBSUP_DIR}" checkout "$GITHUB_SHA"
-git -C "${THUMBSUP_DIR}" pull
 
 echo
 echo


### PR DESCRIPTION
The previous update script was running the code on the `master` branch,
but the GitHub Actions pipeline runs before the changes are merged to
master.

Changed the update script to use the `GITHUB_SHA` environment variable.