### PR TITLE
Fixed update script

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,4 +20,4 @@ jobs:
 
     - name: Update Thumbsup on production server
       run: |
-        ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i deployment.key ubuntu@thumbsup.bugout.dev sudo /home/ubuntu/thumbsup/admin/update.bash
+        ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i deployment.key ubuntu@thumbsup.bugout.dev sudo /home/ubuntu/thumbsup/admin/update.bash "${GITHUB_SHA}"

--- a/admin/update.bash
+++ b/admin/update.bash
@@ -12,13 +12,17 @@ TOKEN_TIMER_FILE="${SCRIPT_DIR}/thumbsuptoken.timer"
 DBWRITE_SERVICE_FILE="${SCRIPT_DIR}/thumbsupdbwrite.service"
 DBWRITE_TIMER_FILE="${SCRIPT_DIR}/thumbsupdbwrite.timer"
 
-GITHUB_SHA=${GITHUB_SHA:-master}
+GITHUB_SHA=${1:-master}
 
 echo
 echo
 echo "Updating Thumbsup codebase at: ${THUMBSUP_DIR} from ${GITHUB_SHA}"
 git -C "${THUMBSUP_DIR}" fetch origin
 git -C "${THUMBSUP_DIR}" checkout "$GITHUB_SHA"
+if [ "$GITHUB_SHA" = "master" ]
+then
+    git -C "${THUMBSUP_DIR}" pull
+fi
 
 echo
 echo


### PR DESCRIPTION
Since we are SSHing into server, the GITHUB_SHA environment variable was
not previously set where the update script ran.

We are now passing it from CI environment to server environment as a
command-line argument.